### PR TITLE
re-add devDependencies babel-preset-stage-0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,8 @@
 {
   "presets": [
     "env",
-    "react"
+    "react",
+    "stage-0"
   ],
   "plugins": [
     [

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-plugin-import": "^1.6.3",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
     "parcel-bundler": "^1.4.1"
   },
   "dependencies": {


### PR DESCRIPTION
sorry,  when babel-preset-stage-0 is removed, arrow functions can't work.
<img width="410" alt="parcel-arrow" src="https://user-images.githubusercontent.com/17308201/35515844-93119caa-054d-11e8-9cb6-06b280fd18a8.png">

> both parcel 1.2.1 and 1.3.1
